### PR TITLE
Add release job to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,3 +20,19 @@ jobs:
     
     - name: Run tests
       run: make test
+
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    
+    - name: Install Nix
+      uses: cachix/install-nix-action@v25
+    
+    - name: Test release build
+      run: nix develop --command goreleaser release --snapshot --clean --parallelism 2


### PR DESCRIPTION
## Summary
• Added a new `release` job to the test workflow that runs goreleaser with snapshot build
• Includes full git history fetch (fetch-depth: 0) required for goreleaser
• Runs goreleaser in snapshot mode with clean build and parallel execution
• Validates that release builds work correctly as part of CI