### PR TITLE
feat: change directory to root when removing current worktree

### DIFF
--- a/cmd/clear.go
+++ b/cmd/clear.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/liamawhite/worktree/pkg/worktree"
 	"github.com/spf13/cobra"
@@ -42,6 +43,15 @@ var clearCmd = &cobra.Command{
 		}
 
 		fmt.Println("Removing all worktrees except main, master and review")
-		return wm.ClearWorktrees()
+		needsChdir, err := wm.ClearWorktrees()
+		if err != nil {
+			return err
+		}
+
+		if needsChdir {
+			fmt.Fprintf(os.Stderr, "WT_CHDIR:%s\n", wm.GitRoot)
+		}
+
+		return nil
 	},
 }

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/liamawhite/worktree/pkg/selector"
@@ -79,6 +80,15 @@ var rmCmd = &cobra.Command{
 		worktreeName := filepath.Base(selectedWorktree)
 		fmt.Printf("Removing worktree: %s\n", worktreeName)
 
-		return wm.RemoveWorktree(selectedWorktree)
+		needsChdir, err := wm.RemoveWorktree(selectedWorktree)
+		if err != nil {
+			return err
+		}
+
+		if needsChdir {
+			fmt.Fprintf(os.Stderr, "WT_CHDIR:%s\n", wm.GitRoot)
+		}
+
+		return nil
 	},
 }


### PR DESCRIPTION
## Summary
• Modified `RemoveWorktree()` and `ClearWorktrees()` functions to detect when the user is currently in a worktree being removed
• Both functions now return a boolean indicating if a directory change is needed
• Commands emit `WT_CHDIR` signal to shell wrapper when removing the current worktree
• Follows the same pattern as the switch command for consistent directory handling across all commands
• Prevents the working directory from becoming invalid after worktree removal