### PR TITLE
feat: add version command and -v flag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,9 +39,9 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X main.version={{.Version}}
-      - -X main.commit={{.FullCommit}}
-      - -X main.date={{.Date}}
+      - -X github.com/liamawhite/worktree/pkg/version.version={{.Version}}
+      - -X github.com/liamawhite/worktree/pkg/version.commit={{.FullCommit}}
+      - -X github.com/liamawhite/worktree/pkg/version.date={{.Date}}
 
 archives:
   - id: worktree

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ SHELL := nix develop --command bash
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-LDFLAGS := -w -s -X main.version=$(VERSION) \
-           -X main.commit=$(COMMIT) \
-           -X main.date=$(DATE)
+LDFLAGS := -w -s -X github.com/liamawhite/worktree/pkg/version.version=$(VERSION) \
+           -X github.com/liamawhite/worktree/pkg/version.commit=$(COMMIT) \
+           -X github.com/liamawhite/worktree/pkg/version.date=$(DATE)
 
 .PHONY: build check clean format lint test-unit dirty
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	"github.com/liamawhite/worktree/pkg/config"
+	"github.com/liamawhite/worktree/pkg/version"
 	"github.com/spf13/cobra"
 )
 
@@ -62,6 +63,11 @@ enterprise Git hosting, and interactive worktree switching.`,
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		if showVersion, _ := cmd.Flags().GetBool("version"); showVersion {
+			info := version.GetInfo()
+			fmt.Println(info.String())
+			return
+		}
 		_ = cmd.Help()
 	},
 }
@@ -71,12 +77,16 @@ func init() {
 	defaultPath := getDefaultConfigPath()
 	RootCmd.PersistentFlags().StringP("config", "c", defaultPath, "config file path")
 
+	// Add version flag
+	RootCmd.Flags().BoolP("version", "v", false, "show version information")
+
 	RootCmd.AddCommand(setupCmd)
 	RootCmd.AddCommand(addCmd)
 	RootCmd.AddCommand(rmCmd)
 	RootCmd.AddCommand(clearCmd)
 	RootCmd.AddCommand(switchCmd)
 	RootCmd.AddCommand(configCmd)
+	RootCmd.AddCommand(versionCmd)
 }
 
 // LoadConfigWithOverride loads config using the resolved config path

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,46 @@
+// Copyright 2025 Liam White
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/liamawhite/worktree/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show version information",
+	Long:  "Display the version, build commit, and build date of the worktree CLI.",
+	Run: func(cmd *cobra.Command, args []string) {
+		info := version.GetInfo()
+
+		if jsonOutput, _ := cmd.Flags().GetBool("json"); jsonOutput {
+			jsonStr, err := info.JSON()
+			if err != nil {
+				fmt.Printf("Error formatting JSON: %v\n", err)
+				return
+			}
+			fmt.Println(jsonStr)
+		} else {
+			fmt.Println(info.String())
+		}
+	},
+}
+
+func init() {
+	versionCmd.Flags().BoolP("json", "j", false, "output version information in JSON format")
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,85 @@
+// Copyright 2025 Liam White
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"time"
+)
+
+var (
+	version   = "dev"
+	commit    = "unknown"
+	date      = "unknown"
+	goVersion = runtime.Version()
+)
+
+type Info struct {
+	Version   string `json:"version"`
+	Commit    string `json:"commit"`
+	Date      string `json:"date"`
+	GoVersion string `json:"goVersion"`
+}
+
+func Get() string {
+	return version
+}
+
+func GetCommit() string {
+	return commit
+}
+
+func GetDate() string {
+	return date
+}
+
+func GetGoVersion() string {
+	return goVersion
+}
+
+func GetInfo() Info {
+	return Info{
+		Version:   version,
+		Commit:    commit,
+		Date:      date,
+		GoVersion: goVersion,
+	}
+}
+
+func (i Info) String() string {
+	var dateStr string
+	if i.Date != "unknown" {
+		if t, err := time.Parse(time.RFC3339, i.Date); err == nil {
+			dateStr = t.Format("2006-01-02 15:04:05 UTC")
+		} else {
+			dateStr = i.Date
+		}
+	} else {
+		dateStr = i.Date
+	}
+
+	return fmt.Sprintf("worktree version %s\ncommit: %s\nbuilt: %s\ngo: %s",
+		i.Version, i.Commit, dateStr, i.GoVersion)
+}
+
+func (i Info) JSON() (string, error) {
+	data, err := json.MarshalIndent(i, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}


### PR DESCRIPTION
## Summary
• Add comprehensive version system with build-time information injection
• Implement `version` command with optional JSON output via `--json` flag
• Add `-v/--version` flag to root command for quick version display
• Update build toolchain (Makefile and GoReleaser) to inject version info at compile time
• Version information includes version tag, git commit, build date, and Go version

## Test plan
- [x] Build system correctly injects version information
- [x] `wt version` displays formatted version information
- [x] `wt -v` shows same version information as shortcut
- [x] `wt version --json` outputs structured JSON format
- [x] GoReleaser configuration validates successfully
- [x] All quality checks pass (formatting, linting, tests)